### PR TITLE
Fix vercel deployment localhost connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Frontend Environment Variables
+# Set this to your deployed backend URL
+VITE_API_URL=https://your-backend-url.com/api/v1
+
+# Example for local development:
+# VITE_API_URL=http://localhost:5000/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Testing
+coverage/
+
+# Production
+dist/
+build/
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+*.log
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/DEPLOYMENT_FIX.md
+++ b/DEPLOYMENT_FIX.md
@@ -1,0 +1,93 @@
+# Fixing the Vercel Deployment Error
+
+The error `Failed to load resource: net::ERR_CONNECTION_REFUSED` at `localhost:5000/api/v1/auth/login` occurs because your frontend deployed on Vercel is trying to connect to a localhost backend that doesn't exist in production.
+
+## Solution Steps
+
+### 1. Deploy Your Backend
+
+Your backend needs to be deployed separately. Here are some options:
+
+#### Option A: Deploy on Render (Recommended - Free tier available)
+1. Create an account on [Render](https://render.com)
+2. Connect your GitHub repository
+3. Create a new Web Service
+4. Set the following:
+   - Build Command: `cd backend && npm install`
+   - Start Command: `cd backend && npm start`
+   - Environment Variables (add these in Render dashboard):
+     ```
+     NODE_ENV=production
+     PORT=5000
+     JWT_SECRET=your-secret-key
+     DATABASE_URL=your-database-url
+     ```
+
+#### Option B: Deploy on Railway
+1. Create an account on [Railway](https://railway.app)
+2. Connect your GitHub repository
+3. Deploy the backend directory
+4. Add the required environment variables
+
+#### Option C: Deploy on Heroku (Paid only now)
+1. Create a Heroku app
+2. Deploy the backend directory
+3. Add environment variables
+
+### 2. Update Frontend Environment Variable on Vercel
+
+Once your backend is deployed, you'll get a URL like:
+- Render: `https://your-app.onrender.com`
+- Railway: `https://your-app.up.railway.app`
+
+1. Go to your Vercel project dashboard
+2. Navigate to Settings → Environment Variables
+3. Add the following variable:
+   ```
+   VITE_API_URL = https://your-backend-url.com/api/v1
+   ```
+   (Replace with your actual backend URL)
+
+### 3. Redeploy on Vercel
+
+After adding the environment variable:
+1. Go to the Deployments tab in Vercel
+2. Click on the three dots menu on your latest deployment
+3. Select "Redeploy"
+
+### 4. Verify the Fix
+
+After redeployment, your frontend should connect to the production backend instead of localhost.
+
+## Local Development
+
+For local development, create a `.env` file in your project root:
+```
+VITE_API_URL=http://localhost:5000/api/v1
+```
+
+This file is already in `.gitignore` so it won't be committed to your repository.
+
+## Backend Deployment Checklist
+
+Before deploying the backend, ensure:
+- [ ] Database is set up (PostgreSQL/Supabase)
+- [ ] All environment variables are configured
+- [ ] CORS is properly configured to allow your Vercel domain
+- [ ] JWT_SECRET is set for authentication
+- [ ] Database migrations are run
+
+## CORS Configuration
+
+Make sure your backend allows requests from your Vercel domain. In your backend, update the CORS configuration:
+
+```javascript
+app.use(cors({
+  origin: [
+    'http://localhost:5173',
+    'https://your-app.vercel.app',
+    'https://your-custom-domain.com'
+  ],
+  credentials: true
+}));
+```

--- a/DEPLOYMENT_SUMMARY.md
+++ b/DEPLOYMENT_SUMMARY.md
@@ -1,0 +1,42 @@
+# Quick Fix for Vercel Deployment Error
+
+## The Problem
+Your frontend on Vercel is trying to connect to `localhost:5000` which doesn't exist in production.
+
+## The Solution
+
+### Step 1: Deploy Your Backend
+Choose one of these platforms:
+- **Render** (Free tier): Use the `backend/render.yaml` file I created
+- **Railway**: Simple GitHub integration
+- **Heroku**: Requires payment
+
+### Step 2: Set Environment Variables in Vercel
+1. Go to your Vercel project → Settings → Environment Variables
+2. Add: `VITE_API_URL = https://your-backend-url.com/api/v1`
+
+### Step 3: Set Backend Environment Variables
+On your backend hosting platform, set:
+```
+DATABASE_URL=your-database-connection-string
+JWT_SECRET=your-secret-key
+FRONTEND_URL=https://your-vercel-app.vercel.app
+```
+
+### Step 4: Redeploy
+Redeploy both frontend (Vercel) and backend.
+
+## Files Created/Updated
+- `.env.example` - Frontend environment example
+- `.gitignore` - To exclude sensitive files
+- `backend/.env.example` - Backend environment example
+- `backend/render.yaml` - Render deployment config
+- `DEPLOYMENT_FIX.md` - Detailed guide
+
+## Next Steps
+1. Deploy your backend first
+2. Get the backend URL
+3. Update Vercel environment variable
+4. Redeploy on Vercel
+
+That's it! Your app should work after these steps.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,23 +1,18 @@
-# Database Configuration
-DATABASE_URL=postgresql://username:password@localhost:5432/osoul_reporting
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=osoul_reporting
-DB_USER=your_db_user
-DB_PASSWORD=your_db_password
+# Backend Environment Variables
 
 # Server Configuration
+NODE_ENV=production
 PORT=5000
-NODE_ENV=development
+
+# Database Configuration
+DATABASE_URL=postgresql://username:password@host:port/database_name
 
 # JWT Configuration
-JWT_SECRET=your_jwt_secret_key_here
+JWT_SECRET=your-very-secure-secret-key
 JWT_EXPIRE=7d
 
-# API Configuration
-API_VERSION=v1
-RATE_LIMIT_WINDOW=15
-RATE_LIMIT_MAX=100
+# Frontend URL for CORS
+FRONTEND_URL=https://your-app.vercel.app
 
-# Frontend URL (for CORS)
-FRONTEND_URL=http://localhost:5173
+# Optional: Logging
+LOG_LEVEL=info

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -1,0 +1,21 @@
+services:
+  - type: web
+    name: osoul-collection-backend
+    env: node
+    region: oregon
+    plan: free
+    buildCommand: npm install
+    startCommand: npm start
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: 5000
+      - key: DATABASE_URL
+        sync: false
+      - key: JWT_SECRET
+        generateValue: true
+      - key: JWT_EXPIRE
+        value: 7d
+      - key: FRONTEND_URL
+        sync: false


### PR DESCRIPTION
Add deployment configurations and guides to fix `ERR_CONNECTION_REFUSED` for Vercel deployments.

The frontend deployed on Vercel was attempting to connect to `localhost:5000`, which is not available in a production environment. This PR introduces necessary environment variable configurations, `.gitignore` for sensitive files, and detailed deployment guides for both frontend and backend (specifically for Render) to ensure the frontend can correctly connect to a deployed backend.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-c94529f7-635d-43fe-a012-223b2752436a) · [Cursor](https://cursor.com/background-agent?bcId=bc-c94529f7-635d-43fe-a012-223b2752436a)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)