### PR TITLE
Build project with vite and fix errors

### DIFF
--- a/node_modules/.bin/autoprefixer
+++ b/node_modules/.bin/autoprefixer
@@ -1,17 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
-esac
-
-if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules:/workspace/node_modules/.pnpm/node_modules"
-else
-  export NODE_PATH="/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
-fi
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
-else
-  exec node  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
-fi
+../autoprefixer/bin/autoprefixer

--- a/node_modules/.bin/eslint
+++ b/node_modules/.bin/eslint
@@ -1,17 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
-esac
-
-if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules:/workspace/node_modules/.pnpm/node_modules"
-else
-  export NODE_PATH="/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
-fi
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../eslint/bin/eslint.js" "$@"
-else
-  exec node  "$basedir/../eslint/bin/eslint.js" "$@"
-fi
+../eslint/bin/eslint.js

--- a/node_modules/.bin/vite
+++ b/node_modules/.bin/vite
@@ -1,17 +1,1 @@
-#!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
-
-case `uname` in
-    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
-esac
-
-if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/workspace/node_modules/.pnpm/vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite/bin/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1/node_modules:/workspace/node_modules/.pnpm/node_modules"
-else
-  export NODE_PATH="/workspace/node_modules/.pnpm/vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite/bin/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
-fi
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"
-else
-  exec node  "$basedir/../vite/bin/vite.js" "$@"
-fi
+../vite/bin/vite.js

--- a/node_modules/@eslint/js
+++ b/node_modules/@eslint/js
@@ -1,1 +1,0 @@
-../.pnpm/@eslint+js@9.26.0/node_modules/@eslint/js

--- a/node_modules/@hookform/resolvers
+++ b/node_modules/@hookform/resolvers
@@ -1,1 +1,0 @@
-../.pnpm/@hookform+resolvers@5.0.1_react-hook-form@7.56.3_react@19.1.0_/node_modules/@hookform/resolvers

--- a/node_modules/@radix-ui/react-accordion
+++ b/node_modules/@radix-ui/react-accordion
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-accordion@1.2.10_@types+react-dom@19.1.5_@types+react@19.1.4__@types+re_33b3c3849e613db1861f4a669149866a/node_modules/@radix-ui/react-accordion

--- a/node_modules/@radix-ui/react-alert-dialog
+++ b/node_modules/@radix-ui/react-alert-dialog
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-alert-dialog@1.1.13_@types+react-dom@19.1.5_@types+react@19.1.4__@types_17802935cec03690054adde829027fd0/node_modules/@radix-ui/react-alert-dialog

--- a/node_modules/@radix-ui/react-aspect-ratio
+++ b/node_modules/@radix-ui/react-aspect-ratio
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-aspect-ratio@1.1.6_@types+react-dom@19.1.5_@types+react@19.1.4__@types+_34ed2ca81e7d30f2a9d836a865ef1416/node_modules/@radix-ui/react-aspect-ratio

--- a/node_modules/@radix-ui/react-avatar
+++ b/node_modules/@radix-ui/react-avatar
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-avatar@1.1.9_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@_ae22d3c08f620c8af31b550306a6f8e0/node_modules/@radix-ui/react-avatar

--- a/node_modules/@radix-ui/react-checkbox
+++ b/node_modules/@radix-ui/react-checkbox
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-checkbox@1.3.1_@types+react-dom@19.1.5_@types+react@19.1.4__@types+reac_d0c2ef0dc489f4008345383d8b44b1c7/node_modules/@radix-ui/react-checkbox

--- a/node_modules/@radix-ui/react-collapsible
+++ b/node_modules/@radix-ui/react-collapsible
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-collapsible@1.1.10_@types+react-dom@19.1.5_@types+react@19.1.4__@types+_922dbe19c23c19c8168fe068ba1cc879/node_modules/@radix-ui/react-collapsible

--- a/node_modules/@radix-ui/react-context-menu
+++ b/node_modules/@radix-ui/react-context-menu
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-context-menu@2.2.14_@types+react-dom@19.1.5_@types+react@19.1.4__@types_0fd532bf7ac3e8efaf5f366fdba554ae/node_modules/@radix-ui/react-context-menu

--- a/node_modules/@radix-ui/react-dialog
+++ b/node_modules/@radix-ui/react-dialog
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-dialog@1.1.13_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react_5ed38e1b3c7e62fec8207201a660395e/node_modules/@radix-ui/react-dialog

--- a/node_modules/@radix-ui/react-dropdown-menu
+++ b/node_modules/@radix-ui/react-dropdown-menu
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-dropdown-menu@2.1.14_@types+react-dom@19.1.5_@types+react@19.1.4__@type_00872994eff604319c9066f0281c9f3a/node_modules/@radix-ui/react-dropdown-menu

--- a/node_modules/@radix-ui/react-hover-card
+++ b/node_modules/@radix-ui/react-hover-card
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-hover-card@1.1.13_@types+react-dom@19.1.5_@types+react@19.1.4__@types+r_f92594d6c267b33d00fcbda1c71ac4f7/node_modules/@radix-ui/react-hover-card

--- a/node_modules/@radix-ui/react-label
+++ b/node_modules/@radix-ui/react-label
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-label@2.1.6_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@1_f5d76421f0b83349b902a67252a7f51f/node_modules/@radix-ui/react-label

--- a/node_modules/@radix-ui/react-menubar
+++ b/node_modules/@radix-ui/react-menubar
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-menubar@1.1.14_@types+react-dom@19.1.5_@types+react@19.1.4__@types+reac_272e421db52877dec2e4cecb9f4f84b4/node_modules/@radix-ui/react-menubar

--- a/node_modules/@radix-ui/react-navigation-menu
+++ b/node_modules/@radix-ui/react-navigation-menu
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-navigation-menu@1.2.12_@types+react-dom@19.1.5_@types+react@19.1.4__@ty_5d266123eb7d50f114f2f7d11484de2f/node_modules/@radix-ui/react-navigation-menu

--- a/node_modules/@radix-ui/react-popover
+++ b/node_modules/@radix-ui/react-popover
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-popover@1.1.13_@types+react-dom@19.1.5_@types+react@19.1.4__@types+reac_40a1abfba6d5eae3fd594012c947e911/node_modules/@radix-ui/react-popover

--- a/node_modules/@radix-ui/react-progress
+++ b/node_modules/@radix-ui/react-progress
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-progress@1.1.6_@types+react-dom@19.1.5_@types+react@19.1.4__@types+reac_6fbf669f5c090fe74335dc4530bf548d/node_modules/@radix-ui/react-progress

--- a/node_modules/@radix-ui/react-radio-group
+++ b/node_modules/@radix-ui/react-radio-group
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-radio-group@1.3.6_@types+react-dom@19.1.5_@types+react@19.1.4__@types+r_39aab6d296b6d794779ce0837f96a2a9/node_modules/@radix-ui/react-radio-group

--- a/node_modules/@radix-ui/react-scroll-area
+++ b/node_modules/@radix-ui/react-scroll-area
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-scroll-area@1.2.8_@types+react-dom@19.1.5_@types+react@19.1.4__@types+r_0931577c8b944290d59f86e3795fb8a9/node_modules/@radix-ui/react-scroll-area

--- a/node_modules/@radix-ui/react-select
+++ b/node_modules/@radix-ui/react-select
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-select@2.2.4_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@_ea725bf78ceaa7c4f15fff075e3a7197/node_modules/@radix-ui/react-select

--- a/node_modules/@radix-ui/react-separator
+++ b/node_modules/@radix-ui/react-separator
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-separator@1.1.6_@types+react-dom@19.1.5_@types+react@19.1.4__@types+rea_d210a7a195800167ad876e0fd1ea8b5e/node_modules/@radix-ui/react-separator

--- a/node_modules/@radix-ui/react-slider
+++ b/node_modules/@radix-ui/react-slider
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-slider@1.3.4_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@_5028e3bbc462b819e09e8c7fb3e2e60c/node_modules/@radix-ui/react-slider

--- a/node_modules/@radix-ui/react-slot
+++ b/node_modules/@radix-ui/react-slot
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-slot@1.2.2_@types+react@19.1.4_react@19.1.0/node_modules/@radix-ui/react-slot

--- a/node_modules/@radix-ui/react-switch
+++ b/node_modules/@radix-ui/react-switch
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-switch@1.2.4_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@_633ca8da003794aaf2f024c24b4e7c67/node_modules/@radix-ui/react-switch

--- a/node_modules/@radix-ui/react-tabs
+++ b/node_modules/@radix-ui/react-tabs
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-tabs@1.1.11_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@1_f95b7add8dea5f03652c4be8d66489a3/node_modules/@radix-ui/react-tabs

--- a/node_modules/@radix-ui/react-toggle
+++ b/node_modules/@radix-ui/react-toggle
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-toggle@1.1.8_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@_b27d69110919cc286898e4a36c18008c/node_modules/@radix-ui/react-toggle

--- a/node_modules/@radix-ui/react-toggle-group
+++ b/node_modules/@radix-ui/react-toggle-group
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-toggle-group@1.1.9_@types+react-dom@19.1.5_@types+react@19.1.4__@types+_7ab0e67bd6f9dfd109e4f2e306c868ac/node_modules/@radix-ui/react-toggle-group

--- a/node_modules/@radix-ui/react-tooltip
+++ b/node_modules/@radix-ui/react-tooltip
@@ -1,1 +1,0 @@
-../.pnpm/@radix-ui+react-tooltip@1.2.6_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react_77fd30315bd1adbf71ffcb3d3c7056c6/node_modules/@radix-ui/react-tooltip

--- a/node_modules/@tailwindcss/postcss
+++ b/node_modules/@tailwindcss/postcss
@@ -1,1 +1,0 @@
-../.pnpm/@tailwindcss+postcss@4.1.11/node_modules/@tailwindcss/postcss

--- a/node_modules/@tailwindcss/vite
+++ b/node_modules/@tailwindcss/vite
@@ -1,1 +1,0 @@
-../.pnpm/@tailwindcss+vite@4.1.7_vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1_/node_modules/@tailwindcss/vite

--- a/node_modules/@types/react
+++ b/node_modules/@types/react
@@ -1,1 +1,0 @@
-../.pnpm/@types+react@19.1.4/node_modules/@types/react

--- a/node_modules/@types/react-dom
+++ b/node_modules/@types/react-dom
@@ -1,1 +1,0 @@
-../.pnpm/@types+react-dom@19.1.5_@types+react@19.1.4/node_modules/@types/react-dom

--- a/node_modules/@vitejs/plugin-react
+++ b/node_modules/@vitejs/plugin-react
@@ -1,1 +1,0 @@
-../.pnpm/@vitejs+plugin-react@4.4.1_vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1_/node_modules/@vitejs/plugin-react

--- a/node_modules/autoprefixer
+++ b/node_modules/autoprefixer
@@ -1,1 +1,0 @@
-.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer

--- a/node_modules/axios
+++ b/node_modules/axios
@@ -1,1 +1,0 @@
-.pnpm/axios@1.10.0/node_modules/axios

--- a/node_modules/class-variance-authority
+++ b/node_modules/class-variance-authority
@@ -1,1 +1,0 @@
-.pnpm/class-variance-authority@0.7.1/node_modules/class-variance-authority

--- a/node_modules/clsx
+++ b/node_modules/clsx
@@ -1,1 +1,0 @@
-.pnpm/clsx@2.1.1/node_modules/clsx

--- a/node_modules/cmdk
+++ b/node_modules/cmdk
@@ -1,1 +1,0 @@
-.pnpm/cmdk@1.1.1_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@19.1.4_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/cmdk

--- a/node_modules/date-fns
+++ b/node_modules/date-fns
@@ -1,1 +1,0 @@
-.pnpm/date-fns@4.1.0/node_modules/date-fns

--- a/node_modules/embla-carousel-react
+++ b/node_modules/embla-carousel-react
@@ -1,1 +1,0 @@
-.pnpm/embla-carousel-react@8.6.0_react@19.1.0/node_modules/embla-carousel-react

--- a/node_modules/eslint
+++ b/node_modules/eslint
@@ -1,1 +1,0 @@
-.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint

--- a/node_modules/eslint-plugin-react-hooks
+++ b/node_modules/eslint-plugin-react-hooks
@@ -1,1 +1,0 @@
-.pnpm/eslint-plugin-react-hooks@5.2.0_eslint@9.26.0_jiti@2.4.2_/node_modules/eslint-plugin-react-hooks

--- a/node_modules/eslint-plugin-react-refresh
+++ b/node_modules/eslint-plugin-react-refresh
@@ -1,1 +1,0 @@
-.pnpm/eslint-plugin-react-refresh@0.4.20_eslint@9.26.0_jiti@2.4.2_/node_modules/eslint-plugin-react-refresh

--- a/node_modules/framer-motion
+++ b/node_modules/framer-motion
@@ -1,1 +1,0 @@
-.pnpm/framer-motion@12.15.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/framer-motion

--- a/node_modules/globals
+++ b/node_modules/globals
@@ -1,1 +1,0 @@
-.pnpm/globals@16.1.0/node_modules/globals

--- a/node_modules/input-otp
+++ b/node_modules/input-otp
@@ -1,1 +1,0 @@
-.pnpm/input-otp@1.4.2_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/input-otp

--- a/node_modules/lucide-react
+++ b/node_modules/lucide-react
@@ -1,1 +1,0 @@
-.pnpm/lucide-react@0.510.0_react@19.1.0/node_modules/lucide-react

--- a/node_modules/next-themes
+++ b/node_modules/next-themes
@@ -1,1 +1,0 @@
-.pnpm/next-themes@0.4.6_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/next-themes

--- a/node_modules/postcss
+++ b/node_modules/postcss
@@ -1,1 +1,0 @@
-.pnpm/postcss@8.5.6/node_modules/postcss

--- a/node_modules/react
+++ b/node_modules/react
@@ -1,1 +1,0 @@
-.pnpm/react@19.1.0/node_modules/react

--- a/node_modules/react-day-picker
+++ b/node_modules/react-day-picker
@@ -1,1 +1,0 @@
-.pnpm/react-day-picker@8.10.1_date-fns@4.1.0_react@19.1.0/node_modules/react-day-picker

--- a/node_modules/react-dom
+++ b/node_modules/react-dom
@@ -1,1 +1,0 @@
-.pnpm/react-dom@19.1.0_react@19.1.0/node_modules/react-dom

--- a/node_modules/react-grid-layout
+++ b/node_modules/react-grid-layout
@@ -1,1 +1,0 @@
-.pnpm/react-grid-layout@1.5.2_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/react-grid-layout

--- a/node_modules/react-hook-form
+++ b/node_modules/react-hook-form
@@ -1,1 +1,0 @@
-.pnpm/react-hook-form@7.56.3_react@19.1.0/node_modules/react-hook-form

--- a/node_modules/react-query
+++ b/node_modules/react-query
@@ -1,1 +1,0 @@
-.pnpm/react-query@3.39.3_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/react-query

--- a/node_modules/react-resizable-panels
+++ b/node_modules/react-resizable-panels
@@ -1,1 +1,0 @@
-.pnpm/react-resizable-panels@3.0.2_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/react-resizable-panels

--- a/node_modules/react-router-dom
+++ b/node_modules/react-router-dom
@@ -1,1 +1,0 @@
-.pnpm/react-router-dom@7.7.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/react-router-dom

--- a/node_modules/recharts
+++ b/node_modules/recharts
@@ -1,1 +1,0 @@
-.pnpm/recharts@2.15.3_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/recharts

--- a/node_modules/sonner
+++ b/node_modules/sonner
@@ -1,1 +1,0 @@
-.pnpm/sonner@2.0.3_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/sonner

--- a/node_modules/tailwind-merge
+++ b/node_modules/tailwind-merge
@@ -1,1 +1,0 @@
-.pnpm/tailwind-merge@3.3.0/node_modules/tailwind-merge

--- a/node_modules/tailwindcss
+++ b/node_modules/tailwindcss
@@ -1,1 +1,0 @@
-.pnpm/tailwindcss@4.1.7/node_modules/tailwindcss

--- a/node_modules/tw-animate-css
+++ b/node_modules/tw-animate-css
@@ -1,1 +1,0 @@
-.pnpm/tw-animate-css@1.2.9/node_modules/tw-animate-css

--- a/node_modules/vaul
+++ b/node_modules/vaul
@@ -1,1 +1,0 @@
-.pnpm/vaul@1.1.2_@types+react-dom@19.1.5_@types+react@19.1.4__@types+react@19.1.4_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/vaul

--- a/node_modules/vite
+++ b/node_modules/vite
@@ -1,1 +1,0 @@
-.pnpm/vite@6.3.5_jiti@2.4.2_lightningcss@1.30.1/node_modules/vite

--- a/node_modules/zod
+++ b/node_modules/zod
@@ -1,1 +1,0 @@
-.pnpm/zod@3.24.4/node_modules/zod

--- a/node_modules/zustand
+++ b/node_modules/zustand
@@ -1,1 +1,0 @@
-.pnpm/zustand@4.5.7_@types+react@19.1.4_react@19.1.0/node_modules/zustand

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
-/ postcss.config.js
+// postcss.config.js
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./index.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,5 @@
 /* src/index.css */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+/* Custom styles - Tailwind is imported in App.css */
 
 @layer base {
   :root {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import AppRouter from './AppRouter'
-import './index.css'
+import './App.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,12 @@
 // vite.config.js
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
Refactor Tailwind CSS v4 configuration and consolidate CSS imports to fix build failures.

The build was failing because Tailwind CSS v4 directives were being incorrectly parsed as JavaScript decorators due to an outdated PostCSS setup and conflicting CSS imports. This PR updates the Vite and PostCSS configurations for Tailwind CSS v4 and reorganizes the CSS import hierarchy to resolve these issues.

---

[Open in Web](https://www.cursor.com/agents?id=bc-7230a7fc-7748-4898-994d-51c9d62e4d2f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7230a7fc-7748-4898-994d-51c9d62e4d2f)