### PR TITLE
Build frontend project with vite

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -5,7 +5,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { toast } from 'sonner';
 import { Loader2, LogIn } from 'lucide-react';
-import authService from '../services/authService';
+import authService from '../services/auth.service';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';


### PR DESCRIPTION
Fix build failure by correcting the import path for `auth.service.js` in `Login.jsx`.

The build was failing because `src/pages/Login.jsx` was attempting to import `authService` from `../services/authService`, but the actual file was named `auth.service.js`. This change updates the import statement to match the correct filename, resolving the "Could not resolve" error.

---

[Open in Web](https://www.cursor.com/agents?id=bc-158bd3fc-d632-42af-bc28-07d9c764fd1c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-158bd3fc-d632-42af-bc28-07d9c764fd1c)