### PR TITLE
Fix collection page filter refresh

### DIFF
--- a/FILTER_FIX_SUMMARY.md
+++ b/FILTER_FIX_SUMMARY.md
@@ -1,0 +1,76 @@
+# Collection Pages Filter Fix Summary
+
+## Issue
+The filters in the Collection pages (`src/pages/Collection`) were not refreshing the data when changed. The pages were using mock data and client-side filtering instead of making API calls with the filter parameters.
+
+## Solution Implemented
+
+### 1. **CollectionAccounts.jsx**
+- Added proper API integration using `collectionAccountsService.getAccounts()`
+- Removed client-side filtering logic (`filteredAccounts`)
+- Added debounce mechanism for search input (500ms delay)
+- Filters are now sent to the API as query parameters
+- Added pagination support with `page` and `totalPages` state
+
+### 2. **CollectionActivities.jsx**
+- Integrated `collectionActivitiesService.getActivities()` API call
+- Removed client-side filtering
+- Added debounce mechanism (300ms delay)
+- Filters are properly passed to the API including date selection
+
+### 3. **CollectionLegalCases.jsx**
+- Integrated `legalCasesService.getLegalCases()` API call
+- Removed client-side filtering logic
+- Added debounce with variable delay (500ms for search, 300ms for other filters)
+- Added search filter support
+
+### 4. **CollectionReports.jsx**
+- Complete refactor to add dynamic data fetching
+- Added `useEffect` hook to watch for filter changes
+- Integrated all report service APIs:
+  - `getDailyCollection()`
+  - `getCollectorProductivity()`
+  - `getAgingMovement()`
+  - `getPTPAnalysis()`
+  - `getLegalCases()`
+  - `getSettlementReport()`
+- Added loading state management
+- Added debounce mechanism (300ms)
+
+## Key Changes
+
+1. **API Integration**: All pages now use the collection service methods defined in `src/services/collectionService.js`
+
+2. **Filter Parameters**: Filters are properly formatted and sent to the API:
+   ```javascript
+   const apiFilters = {};
+   if (filters.search) apiFilters.search = filters.search;
+   if (filters.bucket !== 'all') apiFilters.bucket = filters.bucket;
+   // ... other filters
+   ```
+
+3. **Debouncing**: Added debounce to prevent excessive API calls, especially for search inputs
+
+4. **Fallback to Mock Data**: If API calls fail, the pages fall back to mock data to ensure the UI remains functional
+
+5. **Loading States**: Added proper loading state management for better UX
+
+## Benefits
+
+- **Real-time Updates**: Data now refreshes automatically when filters change
+- **Server-side Filtering**: Better performance for large datasets
+- **Reduced Client Load**: No need to filter large arrays in the browser
+- **Consistent Behavior**: All Collection pages now follow the same pattern
+- **Better UX**: Debouncing prevents UI jank from rapid filter changes
+
+## Testing
+
+To test the fixes:
+1. Navigate to any Collection page
+2. Change any filter (search, bucket, status, etc.)
+3. Observe that the data updates automatically
+4. Check the network tab to verify API calls are being made with correct parameters
+
+## Note
+
+The backend API endpoints need to be properly implemented to handle these filter parameters. The current implementation falls back to mock data if the API is not available or returns an error.


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix Collection page filters not refreshing data by integrating API calls.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, Collection pages (`Accounts`, `Activities`, `Legal Cases`, `Reports`) relied on static mock data and client-side filtering. This prevented filters from triggering data refreshes and led to incorrect results. This PR refactors these pages to fetch data dynamically from the API, remove client-side filtering, and add debouncing for filter changes.

---

[Open in Web](https://www.cursor.com/agents?id=bc-8a4a020c-2379-4f6b-9d80-bdb280c92729) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8a4a020c-2379-4f6b-9d80-bdb280c92729)