### PR TITLE
Build project with vite and resolve next-themes import

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4390,6 +4390,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "clsx": "^2.0.0",
         "date-fns": "^2.30.0",
         "lucide-react": "^0.303.0",
+        "next-themes": "^0.2.1",
         "react": "^18.2.0",
         "react-day-picker": "^9.8.0",
         "react-dom": "^18.2.0",
@@ -4813,6 +4814,17 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "clsx": "^2.0.0",
     "date-fns": "^2.30.0",
     "lucide-react": "^0.303.0",
+    "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-day-picker": "^9.8.0",
     "react-dom": "^18.2.0",

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -1,6 +1,7 @@
 // src/AppRouter.jsx
 import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { ThemeProvider } from 'next-themes';
 import Login from './pages/Login';
 import ProtectedRoute from './components/Layout/ProtectedRoute';
 import MainLayout from './components/Layout/MainLayout';
@@ -44,44 +45,46 @@ const TestPage = () => (
 
 const AppRouter = () => {
   return (
-    <Router>
-      <Toaster position="top-right" />
-      <Routes>
-        {/* Test route */}
-        <Route path="/test" element={<TestPage />} />
-        
-        {/* Public routes */}
-        <Route path="/login" element={<Login />} />
-        
-        {/* Protected routes */}
-        <Route element={<ProtectedRoute />}>
-          <Route element={<MainLayout />}>
-            {/* Dashboard */}
-            <Route path="/dashboard" element={<App />} />
-            
-            {/* Collection routes */}
-            <Route path="/collection" element={<CollectionLayout />}>
-              <Route index element={<Navigate to="/collection/dashboard" replace />} />
-              <Route path="dashboard" element={<CollectionDashboard />} />
-              <Route path="reports" element={<CollectionReports />} />
-              <Route path="analytics" element={<CollectionAnalytics />} />
-              <Route path="accounts" element={<CollectionAccounts />} />
-              <Route path="activities" element={<CollectionActivities />} />
-              <Route path="legal" element={<CollectionLegalCases />} />
-              <Route path="settings" element={<ComingSoon title="Collection Settings" />} />
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <Router>
+        <Toaster position="top-right" />
+        <Routes>
+          {/* Test route */}
+          <Route path="/test" element={<TestPage />} />
+          
+          {/* Public routes */}
+          <Route path="/login" element={<Login />} />
+          
+          {/* Protected routes */}
+          <Route element={<ProtectedRoute />}>
+            <Route element={<MainLayout />}>
+              {/* Dashboard */}
+              <Route path="/dashboard" element={<App />} />
+              
+              {/* Collection routes */}
+              <Route path="/collection" element={<CollectionLayout />}>
+                <Route index element={<Navigate to="/collection/dashboard" replace />} />
+                <Route path="dashboard" element={<CollectionDashboard />} />
+                <Route path="reports" element={<CollectionReports />} />
+                <Route path="analytics" element={<CollectionAnalytics />} />
+                <Route path="accounts" element={<CollectionAccounts />} />
+                <Route path="activities" element={<CollectionActivities />} />
+                <Route path="legal" element={<CollectionLegalCases />} />
+                <Route path="settings" element={<ComingSoon title="Collection Settings" />} />
+              </Route>
+              
+              {/* Other routes */}
+              <Route path="/reports" element={<ComingSoon title="Reports" />} />
+              <Route path="/analytics" element={<ComingSoon title="Analytics" />} />
+              <Route path="/settings" element={<ComingSoon title="Settings" />} />
             </Route>
-            
-            {/* Other routes */}
-            <Route path="/reports" element={<ComingSoon title="Reports" />} />
-            <Route path="/analytics" element={<ComingSoon title="Analytics" />} />
-            <Route path="/settings" element={<ComingSoon title="Settings" />} />
           </Route>
-        </Route>
-        
-        {/* Default redirect */}
-        <Route path="/" element={<Navigate to="/dashboard" replace />} />
-      </Routes>
-    </Router>
+          
+          {/* Default redirect */}
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        </Routes>
+      </Router>
+    </ThemeProvider>
   );
 };
 


### PR DESCRIPTION
Add `next-themes` package and `ThemeProvider` to resolve build failure due to unresolved import.

The build was failing with `[vite]: Rollup failed to resolve import "next-themes"` because the package was missing and the application lacked a `ThemeProvider`. This PR installs the dependency and wraps the application with `ThemeProvider` to provide the necessary context for theme-related components.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d003157f-787e-4e36-b09f-f26d4b55fec9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d003157f-787e-4e36-b09f-f26d4b55fec9)