### PR TITLE
Fix auth store import error during build

### DIFF
--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -271,4 +271,5 @@ const useAuthStore = create(
 );
 
 export { useAuthStore };
+export default useAuthStore;
 


### PR DESCRIPTION
Add default export for `useAuthStore` to resolve build error.

The build was failing with a RollupError: `"default" is not exported by "src/stores/authStore.js", imported by "src/components/Layout/ProtectedRoute.jsx"`. This occurred because `useAuthStore` was imported as a default import in `ProtectedRoute.jsx` (and potentially other files), but `authStore.js` only provided a named export. Adding a default export makes both import styles compatible, resolving the build issue.

---

[Open in Web](https://www.cursor.com/agents?id=bc-f7090240-ce62-46bd-8749-8199915de6d6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f7090240-ce62-46bd-8749-8199915de6d6)