### PR TITLE
Fix ethereum provider injection errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,25 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Osoul Modern Reporting System - Islamic Finance Analytics</title>
+    <script>
+      // Handle ethereum provider conflicts from browser extensions
+      if (window.ethereum) {
+        console.log('Ethereum provider already exists, preserving it');
+      }
+      // Prevent errors from multiple wallet extensions trying to inject
+      Object.defineProperty(window, 'ethereum', {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return window._ethereum;
+        },
+        set(val) {
+          if (!window._ethereum) {
+            window._ethereum = val;
+          }
+        }
+      });
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/AuthDebug.jsx
+++ b/src/components/AuthDebug.jsx
@@ -4,7 +4,7 @@ import authService from '../services/auth.service';
 import { getToken } from '../services/api';
 
 const AuthDebug = () => {
-  const { isAuthenticated, user, token, checkAuth } = useAuthStore();
+  const { isAuthenticated, user, token, initializeAuth } = useAuthStore();
   const [debugInfo, setDebugInfo] = useState({});
   
   useEffect(() => {
@@ -41,7 +41,7 @@ const AuthDebug = () => {
 
   const handleCheckAuth = async () => {
     console.log('🔍 Manual auth check triggered');
-    const result = await checkAuth();
+    const result = await initializeAuth();
     console.log('🔍 Manual auth check result:', result);
   };
 

--- a/src/components/Layout/ProtectedRoute.jsx
+++ b/src/components/Layout/ProtectedRoute.jsx
@@ -5,7 +5,7 @@ import { Loader2 } from 'lucide-react';
 
 export default function ProtectedRoute({ children, roles = [] }) {
   const location = useLocation();
-  const { isAuthenticated, user, checkAuth, hasAnyRole } = useAuthStore();
+  const { isAuthenticated, user, initializeAuth, hasAnyRole } = useAuthStore();
   const [isChecking, setIsChecking] = React.useState(true);
   const [isHydrated, setIsHydrated] = React.useState(false);
 
@@ -23,12 +23,12 @@ export default function ProtectedRoute({ children, roles = [] }) {
     
     const verifyAuth = async () => {
       console.log('ProtectedRoute: Starting auth check');
-      const authResult = await checkAuth();
+      const authResult = await initializeAuth();
       console.log('ProtectedRoute: Auth check complete, result:', authResult);
       setIsChecking(false);
     };
     verifyAuth();
-  }, [checkAuth, isHydrated]);
+  }, [initializeAuth, isHydrated]);
 
   console.log('ProtectedRoute render:', { isChecking, isAuthenticated, isHydrated, location: location.pathname });
 
@@ -45,7 +45,7 @@ export default function ProtectedRoute({ children, roles = [] }) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
-  if (roles.length > 0 && !hasAnyRole(...roles)) {
+  if (roles.length > 0 && !hasAnyRole(roles)) {
     return <Navigate to="/unauthorized" replace />;
   }
 


### PR DESCRIPTION
Fixes loading screen by correcting authentication logic and handling Ethereum provider conflicts.

The application was stuck on a loading screen due to a `TypeError` in `ProtectedRoute.jsx` caused by an incorrect function call (`checkAuth` instead of `initializeAuth`) and an improper `hasAnyRole` argument. Ethereum provider injection conflicts from browser extensions were also addressed for a cleaner console.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d2c9f427-71f3-4d2b-88da-1de87edef211) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d2c9f427-71f3-4d2b-88da-1de87edef211)