### PR TITLE
Fix required message on email write

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -36,7 +36,7 @@ export default function Login() {
     formState: { errors },
   } = useForm({
     resolver: zodResolver(loginSchema),
-    mode: 'onBlur',
+    mode: 'onChange',
     reValidateMode: 'onChange',
   });
 
@@ -132,7 +132,7 @@ export default function Login() {
         </div>
 
         {/* Login Form */}
-        <form onSubmit={handleSubmit(onSubmit)} className="login-form">
+        <form onSubmit={handleSubmit(onSubmit)} className="login-form" noValidate>
           <div className="form-group">
             <Label htmlFor="email">Email</Label>
             <Input
@@ -141,9 +141,12 @@ export default function Login() {
               placeholder="admin@osoul.com"
               {...register('email')}
               className={errors.email ? 'error' : ''}
+              autoComplete="email"
             />
             {errors.email && (
-              <span className="error-message">{errors.email.message}</span>
+              <span className="error-message" role="alert">
+                {errors.email.message || 'Required'}
+              </span>
             )}
           </div>
 
@@ -155,9 +158,12 @@ export default function Login() {
               placeholder="••••••••"
               {...register('password')}
               className={errors.password ? 'error' : ''}
+              autoComplete="current-password"
             />
             {errors.password && (
-              <span className="error-message">{errors.password.message}</span>
+              <span className="error-message" role="alert">
+                {errors.password.message || 'Required'}
+              </span>
             )}
           </div>
 


### PR DESCRIPTION
Fix email input showing redundant 'Required' message and improve form validation UX.

The form was displaying a native browser 'Required' message due to HTML5 validation conflicting with `react-hook-form`. This PR adds `noValidate` to the form and changes the validation mode to `onChange` for immediate user feedback, ensuring only `react-hook-form`'s messages are shown.

---

[Open in Web](https://www.cursor.com/agents?id=bc-630a8c18-7ab5-4ba7-8d4f-630d1347453e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-630a8c18-7ab5-4ba7-8d4f-630d1347453e)